### PR TITLE
MSGraph

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ base64 = "0.13.0"
 rand = "0.8.2"
 serde = { version = "1.0.119", features = ["derive"] }
 serde_json = "1.0.61"
+serde-aux = "*"
 sha2 = "0.9.2"
 url = "2.2.0"
 reqwest = "0.11.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ base64 = "0.13.0"
 rand = "0.8.2"
 serde = { version = "1.0.119", features = ["derive"] }
 serde_json = "1.0.61"
-serde-aux = "*"
+serde-aux = "2.1.1"
 sha2 = "0.9.2"
 url = "2.2.0"
 reqwest = "0.11.0"

--- a/examples/src/bin/msgraph.rs
+++ b/examples/src/bin/msgraph.rs
@@ -59,6 +59,7 @@ pub fn config_from_args_ms(name: &str) -> Result<ConfigMS> {
 }
 
 /*
+- M$ Graph OAuth Parameters
 Auth OAuth {
     access_token: None,
     scopes: {"User.ReadAll", "https://graph.microsoft.com/.default"},
@@ -72,7 +73,7 @@ Auth OAuth {
         "redirect_uri": 	"https://login.microsoftonline.com/common/oauth2/nativeclient",
         "refresh_token_url":"https://login.microsoftonline.com/{tenant-domain}/oauth2/token"
         }
-    }5np$1hLHtCcrI9QEgTH7xb6@d6u4r2Z8eGb%i3
+    }
 */
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/examples/src/bin/msgraph.rs
+++ b/examples/src/bin/msgraph.rs
@@ -10,6 +10,7 @@ use anyhow::{anyhow, Result};
 pub struct ConfigMS {
     pub client_id: String,
     pub client_secret: String,
+    /// Tennant ID, Required in the url by M$ 
     pub tenant_domain: String,
 }
 
@@ -58,23 +59,6 @@ pub fn config_from_args_ms(name: &str) -> Result<ConfigMS> {
     })
 }
 
-/*
-- M$ Graph OAuth Parameters
-Auth OAuth {
-    access_token: None,
-    scopes: {"User.ReadAll", "https://graph.microsoft.com/.default"},
-    credentials:
-    {
-        "access_token_url": "https://login.microsoftonline.com/{tenant-domain}/oauth2/token",
-        "authorization_url":"https://login.microsoftonline.com/{tenant-domain}/oauth2/authorize",
-        "client_id": 		"My-ID",
-        "client_secret": 	"pa$$word",
-        "logout_url": 		"https://login.microsoftonline.com/{tenant-domain}/oauth2/logout",
-        "redirect_uri": 	"https://login.microsoftonline.com/common/oauth2/nativeclient",
-        "refresh_token_url":"https://login.microsoftonline.com/{tenant-domain}/oauth2/token"
-        }
-    }
-*/
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let config = config_from_args_ms("msgraph Example")?;

--- a/examples/src/bin/msgraph.rs
+++ b/examples/src/bin/msgraph.rs
@@ -1,0 +1,103 @@
+//! Showcases how to define and use a nonstandard token type.
+//!
+//! Note: MSGraph requires you to set `client_id` and `client_secret` as extra
+//! parameters when performing the token exchange (see below).
+
+use oauth2::{Client, Url, StandardToken};
+
+use anyhow::{anyhow, Result};
+
+
+
+pub struct ConfigMS {
+    pub client_id: String,
+    pub client_secret: String,
+    pub tenant_domain: String,
+}
+
+pub fn config_from_args_ms(name: &str) -> Result<ConfigMS> {
+    let app = clap::App::new(name)
+        .about("Testing out OAuth 2.0 flows")
+        .arg(
+            clap::Arg::with_name("client-id")
+                .takes_value(true)
+                .long("client-id")
+                .help("Client ID to use."),
+        )
+        .arg(
+            clap::Arg::with_name("client-secret")
+                .takes_value(true)
+                .long("client-secret")
+                .help("Client Secret to use."),
+        )
+        .arg(
+            clap::Arg::with_name("tenant-domain")
+                .takes_value(true)
+                .long("tenant-domain")
+                .help("Tenant domain to use."),
+        );
+
+    let m = app.get_matches();
+
+    let client_id = m
+        .value_of("client-id")
+        .ok_or_else(|| anyhow!("missing: --client-id <argument>"))?
+        .to_string();
+    let client_secret = m
+        .value_of("client-secret")
+        .ok_or_else(|| anyhow!("missing: --client-secret <argument>"))?
+        .to_string();
+
+    let  tenant_domain = m
+        .value_of("tenant-domain")
+        .ok_or_else(|| anyhow!("missing: --tenant-domain <argument>"))?
+        .to_string();
+
+    Ok(ConfigMS {
+        client_id,
+        client_secret,
+        tenant_domain,
+    })
+}
+
+/*
+Auth OAuth { 
+	access_token: None, 
+	scopes: {"User.ReadAll", "https://graph.microsoft.com/.default"}, 
+	credentials: 
+	{
+		"access_token_url": "https://login.microsoftonline.com/{tenant-domain}/oauth2/token", 
+		"authorization_url":"https://login.microsoftonline.com/{tenant-domain}/oauth2/authorize", 
+		"client_id": 		"337b2164-0006-41fc-a243-710f3d63c889", 
+		"client_secret": 	"6_uEpej8_vG.-Ph33Pg_Iv82u6QnP~30-E", 
+		"logout_url": 		"https://login.microsoftonline.com/{tenant-domain}/oauth2/logout", 
+		"redirect_uri": 	"https://login.microsoftonline.com/common/oauth2/nativeclient", 
+		"refresh_token_url":"https://login.microsoftonline.com/{tenant-domain}/oauth2/token"
+		}
+	}
+*/
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let config = config_from_args_ms("msgraph Example")?;
+
+    let reqwest_client = reqwest::Client::new();
+
+    let auth_url = Url::parse(format!("https://login.microsoftonline.com/{}/oauth2/authorize", config.tenant_domain).as_str())?;
+    let token_url = Url::parse(format!("https://login.microsoftonline.com/{}/oauth2/token", config.tenant_domain).as_str())?;
+    let redirect_url = Url::parse("https://login.microsoftonline.com/common/oauth2/nativeclient")?;
+    //let refresh_token_url = Url::parse(format!("https://login.microsoftonline.com/{}/oauth2/token", config.tenant_domain).as_str())?;
+
+    let mut client = Client::new(&config.client_id, auth_url, token_url);
+    client.set_client_secret(&config.client_secret);
+    client.set_redirect_url(redirect_url);
+    
+    client.add_scope("User.ReadAll");
+
+    let token_result = client.exchange_client_credentials()
+        .with_client(&reqwest_client)
+        .execute::<StandardToken>()
+        .await?;
+    
+    println!("Token: {:?}", token_result);
+    Ok(())
+}

--- a/examples/src/bin/msgraph.rs
+++ b/examples/src/bin/msgraph.rs
@@ -3,11 +3,9 @@
 //! Note: MSGraph requires you to set `client_id` and `client_secret` as extra
 //! parameters when performing the token exchange (see below).
 
-use oauth2::{Client, Url, StandardToken};
+use oauth2::{Client, StandardToken, Url};
 
 use anyhow::{anyhow, Result};
-
-
 
 pub struct ConfigMS {
     pub client_id: String,
@@ -48,7 +46,7 @@ pub fn config_from_args_ms(name: &str) -> Result<ConfigMS> {
         .ok_or_else(|| anyhow!("missing: --client-secret <argument>"))?
         .to_string();
 
-    let  tenant_domain = m
+    let tenant_domain = m
         .value_of("tenant-domain")
         .ok_or_else(|| anyhow!("missing: --tenant-domain <argument>"))?
         .to_string();
@@ -61,20 +59,20 @@ pub fn config_from_args_ms(name: &str) -> Result<ConfigMS> {
 }
 
 /*
-Auth OAuth { 
-	access_token: None, 
-	scopes: {"User.ReadAll", "https://graph.microsoft.com/.default"}, 
-	credentials: 
-	{
-		"access_token_url": "https://login.microsoftonline.com/{tenant-domain}/oauth2/token", 
-		"authorization_url":"https://login.microsoftonline.com/{tenant-domain}/oauth2/authorize", 
-		"client_id": 		"337b2164-0006-41fc-a243-710f3d63c889", 
-		"client_secret": 	"6_uEpej8_vG.-Ph33Pg_Iv82u6QnP~30-E", 
-		"logout_url": 		"https://login.microsoftonline.com/{tenant-domain}/oauth2/logout", 
-		"redirect_uri": 	"https://login.microsoftonline.com/common/oauth2/nativeclient", 
-		"refresh_token_url":"https://login.microsoftonline.com/{tenant-domain}/oauth2/token"
-		}
-	}
+Auth OAuth {
+    access_token: None,
+    scopes: {"User.ReadAll", "https://graph.microsoft.com/.default"},
+    credentials:
+    {
+        "access_token_url": "https://login.microsoftonline.com/{tenant-domain}/oauth2/token",
+        "authorization_url":"https://login.microsoftonline.com/{tenant-domain}/oauth2/authorize",
+        "client_id": 		"My-ID",
+        "client_secret": 	"pa$$word",
+        "logout_url": 		"https://login.microsoftonline.com/{tenant-domain}/oauth2/logout",
+        "redirect_uri": 	"https://login.microsoftonline.com/common/oauth2/nativeclient",
+        "refresh_token_url":"https://login.microsoftonline.com/{tenant-domain}/oauth2/token"
+        }
+    }5np$1hLHtCcrI9QEgTH7xb6@d6u4r2Z8eGb%i3
 */
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -82,22 +80,35 @@ async fn main() -> anyhow::Result<()> {
 
     let reqwest_client = reqwest::Client::new();
 
-    let auth_url = Url::parse(format!("https://login.microsoftonline.com/{}/oauth2/authorize", config.tenant_domain).as_str())?;
-    let token_url = Url::parse(format!("https://login.microsoftonline.com/{}/oauth2/token", config.tenant_domain).as_str())?;
+    let auth_url = Url::parse(
+        format!(
+            "https://login.microsoftonline.com/{}/oauth2/authorize",
+            config.tenant_domain
+        )
+        .as_str(),
+    )?;
+    let token_url = Url::parse(
+        format!(
+            "https://login.microsoftonline.com/{}/oauth2/token",
+            config.tenant_domain
+        )
+        .as_str(),
+    )?;
     let redirect_url = Url::parse("https://login.microsoftonline.com/common/oauth2/nativeclient")?;
     //let refresh_token_url = Url::parse(format!("https://login.microsoftonline.com/{}/oauth2/token", config.tenant_domain).as_str())?;
 
     let mut client = Client::new(&config.client_id, auth_url, token_url);
     client.set_client_secret(&config.client_secret);
     client.set_redirect_url(redirect_url);
-    
+
     client.add_scope("User.ReadAll");
 
-    let token_result = client.exchange_client_credentials()
+    let token_result = client
+        .exchange_client_credentials()
         .with_client(&reqwest_client)
         .execute::<StandardToken>()
         .await?;
-    
+
     println!("Token: {:?}", token_result);
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,6 +220,7 @@ use std::{borrow::Cow, error, fmt, time::Duration};
 
 use rand::{thread_rng, Rng};
 use serde::{Deserialize, Serialize};
+use serde_aux::prelude::*;
 use sha2::{Digest, Sha256};
 use thiserror::Error;
 pub use url::Url;
@@ -908,7 +909,7 @@ where
 pub struct StandardToken {
     access_token: AccessToken,
     token_type: TokenType,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", deserialize_with = "deserialize_option_number_from_string")]
     expires_in: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     refresh_token: Option<RefreshToken>,


### PR DESCRIPTION
Example for M$Graph, 

Our friends at Microsoft may return "expires_in" as a string which fails to parse.
```
 .\target\debug\msgraph --client-secret "XXXXXX" --client-id "YYYYYYYYYYYYY"  --tenant-domain "ZZZZZZZ"
Error: malformed server response: 200 OK
Caused by: "3599"
```
I had the same problem with [graph-rs]("https://github.com/sreeise/graph-rs/pull/291").

The fix is to use:
```rust
    #[serde(skip_serializing_if = "Option::is_none", deserialize_with = "deserialize_option_number_from_string")]
    expires_in: Option<u64>,
```

```
 .\target\debug\msgraph --client-secret "XXXXXX" --client-id "YYYYYYYYYYYYY"  --tenant-domain "ZZZZZZZ"
Token: StandardToken { access_token: AccessToken([redacted]), token_type: Bearer, expires_in: Some(3599), refresh_token: None, scopes: None }
```