### PR TITLE
Fix parameter name from 'scopes' to 'scope' in client_credentials

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -672,7 +672,7 @@ impl Client {
                 .collect::<Vec<_>>()
                 .join(" ");
 
-            builder = builder.param("scopes", scopes);
+            builder = builder.param("scope", scopes);
         }
 
         builder


### PR DESCRIPTION
See RFC section:
<img width="1696" height="904" alt="image" src="https://github.com/user-attachments/assets/e11264f1-712d-44cd-9f88-15ab90fee771" />

If one could do a release right after, that would be much appreciated as it's critical for us